### PR TITLE
KeyValueStringValidator should check if expression language exists

### DIFF
--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2.java
@@ -292,6 +292,10 @@ public class PutInfluxDBv2 extends AbstractProcessor {
 
         @Override
         public ValidationResult validate(final String subject, final String input, final ValidationContext context) {
+            if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input)) {
+                return (new ValidationResult.Builder()).subject(subject).input(input).explanation("Expression Language Present").valid(true).build();
+            }
+
             List<String> invalids;
             try {
                 invalids = Arrays.stream(parserBuilder.build()

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/main/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2.java
@@ -346,7 +346,8 @@ public class PutInfluxDBv2 extends AbstractProcessor {
         }
 
         /**
-         * Splits s into an array of size 2 where index position 0 is left of equal sign and position 1 is right of equal sign
+         * Splits s into an array of size 2 where index position 0 is left of equal sign and position 1 is right of equal sign.
+         * Both parts (the key and value) of the split must be non blank otherwise returns null
          * @param s The string to split
          * @return array of size 2 or null for invalid input
          */

--- a/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/test/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2Test.java
+++ b/nifi-asymmetrik-standard-bundle/nifi-asymmetrik-standard-processors/src/test/java/com/asymmetrik/nifi/processors/influxdb/PutInfluxDBv2Test.java
@@ -1,11 +1,14 @@
 package com.asymmetrik.nifi.processors.influxdb;
 
 import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.util.MockValidationContext;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PutInfluxDBv2Test {
 
@@ -13,8 +16,7 @@ public class PutInfluxDBv2Test {
     public void testBasicKeyValueStringValidator() {
         final String kvp = "foo=world, bar=hello";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertTrue(vResult.isValid());
+        assertTrue(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
 
@@ -27,17 +29,14 @@ public class PutInfluxDBv2Test {
     @Test
     public void testPartialKeyValueStringValidator() {
         final String kvp = "foo=world, bar=";
-
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertFalse(vResult.isValid());
+        assertFalse(validate(kvp, false, false));
     }
 
     @Test
     public void testQuotedKeyValueStringValidator() {
         final String kvp = "\"foo=hello, world\", bar=hello";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertTrue(vResult.isValid());
+        assertTrue(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
 
@@ -51,8 +50,7 @@ public class PutInfluxDBv2Test {
     public void testInnerQuotesKeyValueStringValidator() {
         final String kvp = "foo=he said \"hello, world\", bar=hello";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertTrue(vResult.isValid());
+        assertTrue(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
 
@@ -66,8 +64,7 @@ public class PutInfluxDBv2Test {
     public void testInnerOuterQuotesKeyValueStringValidator() {
         final String kvp = "foo=he said \"hello, world\", bar=hello";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertTrue(vResult.isValid());
+        assertTrue(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
 
@@ -81,8 +78,7 @@ public class PutInfluxDBv2Test {
     public void testEqualsKeyValueStringValidator() {
         final String kvp = "  =";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertFalse(vResult.isValid());
+        assertFalse(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
         assertTrue(result.isEmpty());
@@ -92,8 +88,7 @@ public class PutInfluxDBv2Test {
     public void testEmptyKeyValueStringValidator() {
         final String kvp = "";
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertFalse(vResult.isValid());
+        assertFalse(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
         assertTrue(result.isEmpty());
@@ -103,10 +98,25 @@ public class PutInfluxDBv2Test {
     public void testNullKeyValueStringValidator() {
         final String kvp = null;
 
-        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate("subject", kvp, null);
-        assertFalse(vResult.isValid());
+        assertFalse(validate(kvp, false, false));
 
         Map<String, String> result =  PutInfluxDBv2.KeyValueStringValidator.parse(kvp);
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testExpressionLanguageKeyValueStringValidator() {
+        final String kvp = "${foo}";
+        assertTrue(validate(kvp, true, true));
+    }
+
+    private boolean validate(String value, boolean expressionLanguageSupported, boolean isExpressionLanguagePresent) {
+        final String subject = "subject";
+        MockValidationContext mockContext = mock(MockValidationContext.class);
+        when(mockContext.isExpressionLanguageSupported(subject)).thenReturn(expressionLanguageSupported);
+        when(mockContext.isExpressionLanguagePresent(value)).thenReturn(isExpressionLanguagePresent);
+
+        ValidationResult vResult = new PutInfluxDBv2.KeyValueStringValidator().validate(subject, value, mockContext);
+        return vResult.isValid();
     }
 }


### PR DESCRIPTION
KeyValueStringValidator.validate should check if "tags" property descriptor value contains any expression language and skip the validation if it does.